### PR TITLE
Fix website and admin doc URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Script that checks whether your websites and servers are up and running
 
 ## Documentation and resources
 
-* Official app website: <www.phpservermonitor.org>
+* Official app website: <https://www.phpservermonitor.org/>
 * Official user documentation: <https://yunohost.org/apps>
-* Official admin documentation: <http://docs.phpservermonitor.org/en/latest/>
+* Official admin documentation: <https://docs.phpservermonitor.org/en/latest/>
 * Upstream app code repository: <https://github.com/phpservermon/phpservermon/>
 * YunoHost Store: <https://apps.yunohost.org/app/phpservermon>
 * Report a bug: <https://github.com/YunoHost-Apps/phpservermon_ynh/issues>

--- a/README_fr.md
+++ b/README_fr.md
@@ -33,9 +33,9 @@ Application pour vérifier que vos sites web et serveurs fonctionnent
 
 ## Documentations et ressources
 
-* Site officiel de l’app : <www.phpservermonitor.org>
+* Site officiel de l’app : <https://www.phpservermonitor.org>
 * Documentation officielle utilisateur : <https://yunohost.org/apps>
-* Documentation officielle de l’admin : <http://docs.phpservermonitor.org/en/latest/>
+* Documentation officielle de l’admin : <https://docs.phpservermonitor.org/en/latest/>
 * Dépôt de code officiel de l’app : <https://github.com/phpservermon/phpservermon/>
 * YunoHost Store: <https://apps.yunohost.org/app/phpservermon>
 * Signaler un bug : <https://github.com/YunoHost-Apps/phpservermon_ynh/issues>

--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,8 @@
     "url": "www.phpservermonitor.org",
     "upstream": {
         "license": "GPL-3.0-or-later",
-        "website": "www.phpservermonitor.org",
-        "admindoc": "http://docs.phpservermonitor.org/en/latest/",
+        "website": "https://www.phpservermonitor.org/",
+        "admindoc": "https://docs.phpservermonitor.org/en/latest/",
         "userdoc": "https://yunohost.org/apps",
         "code": "https://github.com/phpservermon/phpservermon/",
         "cpe": "cpe:2.3:a:phpservermonitor:php_server_monitor"


### PR DESCRIPTION
## Problem

I just found that in the official YNH app catalog the website URL leads to a broken site. When you click the official website link on https://apps.yunohost.org/app/phpservermon it leads to https://apps.yunohost.org/app/www.phpservermonitor.org which is incorrect.

## Solution

I added `https://` to the website link to fix it and also added `https://` to the admin doc link.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
